### PR TITLE
Remove prefix additions

### DIFF
--- a/BotKit.podspec
+++ b/BotKit.podspec
@@ -15,10 +15,4 @@ Pod::Spec.new do |s|
   s.source_files = 'BotKit/**/*.{m,h}'
   s.requires_arc = true
   s.framework    = 'CoreData', 'Accelerate'
-
-  s.prefix_header_contents = <<-EOS
-  #import <Availability.h>
-  #import <CoreData/CoreData.h>
-EOS
-
 end

--- a/BotKit/Controllers/BKManagedViewController.h
+++ b/BotKit/Controllers/BKManagedViewController.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <CoreData/CoreData.h>
 
 @interface BKManagedViewController : UIViewController <NSFetchedResultsControllerDelegate>
 

--- a/BotKit/Models/BKCoreDataManager.h
+++ b/BotKit/Models/BKCoreDataManager.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
 
 @interface BKCoreDataManager : NSObject
 


### PR DESCRIPTION
Cocoapods doesn't wrap the prefix additions in `#ifdef __OBJC_`. This causes a problem when using a pod like `BotKit` alongside a pod like `SSZipArchive`, which includes non-objective-c files. This is a problem with cocoapods, but in all actuality, we don't really need to be adding `CoreData` and `Availability` to the prefix in the first place. So it's probably better to just move these imports to the files that need them.
