### PR TITLE
Fix podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,5 @@
 platform :ios
-target :BotKitTests, excusive: true do
+
+target :BotKitTests, exclusive: true do
   pod 'Kiwi'
 end


### PR DESCRIPTION
- Fixes misspelling of 'exclusive' that caused the Cocoapods to throw errors when attempting to install or update.
