### PR TITLE
Fix Travis CI config to prevent build fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
 before_install:
  - "gem update cocoapods"
- - "which xctool || brew update && brew install xctool --HEAD"
+ - "which xctool || (brew update && brew install xctool --HEAD)"
 script: "xctool test"


### PR DESCRIPTION
I recently tried to copy the Travis CI config from BotKit to use it in our internal project, and found a build error issue  due to some shell script logic error.
